### PR TITLE
Fixed memory leaks in aes.c and cmac.c

### DIFF
--- a/src/aes.c
+++ b/src/aes.c
@@ -9,6 +9,7 @@ unsigned char* aes_128_encrypt(unsigned char* in, unsigned char* out, unsigned c
     w = (unsigned char*)malloc(16 * (Nr + 1));
     KeyExpansion(key, w, Nk, Nr);
     Cipher(in, out, w, Nk, Nr);
+    free(w);
     return out;
 }
 
@@ -19,6 +20,7 @@ unsigned char* aes_128_decrypt(unsigned char* in, unsigned char* out, unsigned c
     w = (unsigned char*)malloc(16 * (Nr + 1));
     KeyExpansion(key, w, Nk, Nr);
     InvCipher(in, out, w, Nk, Nr);
+    free(w);
     return out;
 }
 
@@ -29,6 +31,7 @@ unsigned char* aes_192_encrypt(unsigned char* in, unsigned char* out, unsigned c
     w = (unsigned char*)malloc(16 * (Nr + 1));
     KeyExpansion(key, w, Nk, Nr);
     Cipher(in, out, w, Nk, Nr);
+    free(w);
     return out;
 }
 
@@ -39,6 +42,7 @@ unsigned char* aes_192_decrypt(unsigned char* in, unsigned char* out, unsigned c
     w = (unsigned char*)malloc(16 * (Nr + 1));
     KeyExpansion(key, w, Nk, Nr);
     InvCipher(in, out, w, Nk, Nr);
+    free(w);
     return out;
 }
 
@@ -49,6 +53,7 @@ unsigned char* aes_256_encrypt(unsigned char* in, unsigned char* out, unsigned c
     w = (unsigned char*)malloc(16 * (Nr + 1));
     KeyExpansion(key, w, Nk, Nr);
     Cipher(in, out, w, Nk, Nr);
+    free(w);
     return out;
 }
 
@@ -59,6 +64,7 @@ unsigned char* aes_256_decrypt(unsigned char* in, unsigned char* out, unsigned c
     w = (unsigned char*)malloc(16 * (Nr + 1));
     KeyExpansion(key, w, Nk, Nr);
     InvCipher(in, out, w, Nk, Nr);
+    free(w);
     return out;
 }
 

--- a/src/cmac.c
+++ b/src/cmac.c
@@ -50,6 +50,8 @@ unsigned char* aes_cmac(unsigned char* in, unsigned int length, unsigned char* o
     }
     block_xor(Y, M[n - 1], X);
     aes_128_encrypt(Y, out, key);
+    free(K1);
+    free(K2);
     return out;
 }
 


### PR DESCRIPTION
Functions in aes.c and cmac.c were using malloc with local variables without freeing this memory. Now memory leaks are fixed, and aes_encrypt can be looped without restrictions.